### PR TITLE
update manifests to avoid the LoadRestrictionsNone

### DIFF
--- a/config/overlays/odh/default/kustomization.yaml
+++ b/config/overlays/odh/default/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - files:
+      - ./config-defaults.yaml
+    name: model-serving-config-defaults
+
+transformers:
+  - ./default/metadataLabelTransformer.yaml

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -17,10 +17,7 @@ configMapGenerator:
     name: mesh-parameters
 generatorOptions:
   disableNameSuffixHash: true
-
-transformers:
-  - ./default/metadataLabelTransformer.yaml
-
+  
 vars:
   - fieldref:
       fieldPath: metadata.namespace

--- a/config/overlays/odh/manager/kustomization.yaml
+++ b/config/overlays/odh/manager/kustomization.yaml
@@ -2,13 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../manager/manager.yaml
+  - ../../../manager
   - ./service.yaml
-
-configMapGenerator:
-  - files:
-      - ../default/config-defaults.yaml
-    name: model-serving-config-defaults
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
previously we should have added an option `LoadRestrictionsNone` but it does not look right. So I slightly changed the structure of manifests and it helps not to require the option.

@VedantMahabaleshwarkar could you please check the result manifsts with original one? 